### PR TITLE
Don't use a top scope variable for domain

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,12 +53,12 @@ class kerberos(
       "${realm}" => {
         'kdc' => $_kdc_hostnames,
         'admin_server' => $_kadmin_hostname,
-        'default_domain' => $::domain,
+        'default_domain' => $domain,
       },
     },
     'domain_realm' => {
-      ".${::domain}" => $realm,
-      "${::domain}" => $realm,
+      ".${domain}" => $realm,
+      "${domain}" => $realm,
     },
   }, $client_properties)
   $_kdc_properties = deep_merge({


### PR DESCRIPTION
Hi,

Since you already allow the $domain variable to be overriden during the class assignment, it's probably a good idea to not access the top scope variable in the code itself. We have a requirement to use a different domain than the one retrieved from Puppet facts, so this change would help us.

RSpec test were passed